### PR TITLE
can now default datetimepicker tab to initialize on time tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ or
 .setIndicatorColor(Color.parseColor("#FF0000"))
 ```
 
+**To specify the which picker to default to:**
+```java
+.setDefaultSelector(SlideDateTimePicker.DefaultSelector.TIME)
+```
+
 **To specify the color of the horizontal divider lines in the DatePicker and TimePicker:**
 You can also set a custom color for the horizontal divider lines in the DatePicker and TimePicker, but for this you have to paste your own version of selection_divider.9.png into the the library's drawable-xxxx folders that has your desired color. To do this, open selection_divider.9.png in a graphics editor, change the color, then paste your new files into the drawable-xxxx folders.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ or
 ```java
 .setDefaultSelector(SlideDateTimePicker.DefaultSelector.TIME)
 ```
+or
+```
+.setDefaultSelector(SlideDateTimePicker.DefaultSelector.DATE)
+```
 
 **To specify the color of the horizontal divider lines in the DatePicker and TimePicker:**
 You can also set a custom color for the horizontal divider lines in the DatePicker and TimePicker, but for this you have to paste your own version of selection_divider.9.png into the the library's drawable-xxxx folders that has your desired color. To do this, open selection_divider.9.png in a graphics editor, change the color, then paste your new files into the drawable-xxxx folders.

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,16 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Fri Jun 09 11:00:27 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 09 11:00:27 PDT 2017
+#Wed Oct 25 13:34:51 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/slideDateTimePicker/build.gradle
+++ b/slideDateTimePicker/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 14

--- a/slideDateTimePicker/build.gradle
+++ b/slideDateTimePicker/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 26
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 26
     }
 
     buildTypes {
@@ -15,8 +14,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
-}
-
-dependencies {
-    compile 'com.android.support:support-v4:23.1.1'
+    dependencies {
+        implementation 'com.android.support:support-v4:26.1.0'
+    }
 }

--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/CustomViewPager.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/CustomViewPager.java
@@ -54,18 +54,19 @@ public class CustomViewPager extends ViewPager
     @Override
     public void onMeasure(int widthMeasureSpec, int heightMeasureSpec)
     {
-        int height = 0;
+        int mode = MeasureSpec.getMode(heightMeasureSpec);
 
-        for (int i = 0; i < getChildCount(); i++)
-        {
-            View child = getChildAt(i);
-            child.measure(widthMeasureSpec, MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
-            int h = child.getMeasuredHeight();
-            if (h > height)
-                height = h;
+        if (mode == MeasureSpec.UNSPECIFIED || mode == MeasureSpec.AT_MOST) {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+            int height = 0;
+            for(int i = 0; i < getChildCount(); i++){
+                View child = getChildAt(i);
+                child.measure(widthMeasureSpec, MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
+                int h = child.getMeasuredHeight();
+                if(h > height) height = h;
+            }
+            heightMeasureSpec = MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY);
         }
-
-        heightMeasureSpec = MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY);
 
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 

--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/DateFragment.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/DateFragment.java
@@ -50,7 +50,7 @@ public class DateFragment extends Fragment
 
         try
         {
-            mCallback = (DateChangedListener) getTargetFragment();
+            mCallback = (DateChangedListener) getParentFragment();
         }
         catch (ClassCastException e)
         {
@@ -62,7 +62,7 @@ public class DateFragment extends Fragment
     /**
      * Return an instance of DateFragment with its bundle filled with the
      * constructor arguments. The values in the bundle are retrieved in
-     * {@link #onCreateView()} below to properly initialize the DatePicker.
+     * {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)} below to properly initialize the DatePicker.
      *
      * @param theme
      * @param year

--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimeDialogFragment.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimeDialogFragment.java
@@ -383,24 +383,22 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
             switch (position)
             {
             case 0:
-                DateFragment dateFragment = DateFragment.newInstance(
+                //dateFragment.setTargetFragment(SlideDateTimeDialogFragment.this, 100);
+                return DateFragment.newInstance(
                     mTheme,
                     mCalendar.get(Calendar.YEAR),
                     mCalendar.get(Calendar.MONTH),
                     mCalendar.get(Calendar.DAY_OF_MONTH),
                     mMinDate,
                     mMaxDate);
-                dateFragment.setTargetFragment(SlideDateTimeDialogFragment.this, 100);
-                return dateFragment;
             case 1:
-                TimeFragment timeFragment = TimeFragment.newInstance(
+                //timeFragment.setTargetFragment(SlideDateTimeDialogFragment.this, 200);
+                return TimeFragment.newInstance(
                     mTheme,
                     mCalendar.get(Calendar.HOUR_OF_DAY),
                     mCalendar.get(Calendar.MINUTE),
                     mIsClientSpecified24HourTime,
                     mIs24HourTime);
-                timeFragment.setTargetFragment(SlideDateTimeDialogFragment.this, 200);
-                return timeFragment;
             default:
                 return null;
             }

--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimeDialogFragment.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimeDialogFragment.java
@@ -21,6 +21,8 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.Button;
 
+import static com.github.jjobes.slidedatetimepicker.SlideDateTimePicker.*;
+
 /**
  * <p>The {@code DialogFragment} that contains the {@link SlidingTabLayout}
  * and {@link CustomViewPager}.</p>
@@ -36,7 +38,6 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
                                                                            TimeFragment.TimeChangedListener
 {
     public static final String TAG_SLIDE_DATE_TIME_DIALOG_FRAGMENT = "tagSlideDateTimeDialogFragment";
-
     private static SlideDateTimeListener mListener;
 
     private Context mContext;
@@ -54,7 +55,7 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
     private Date mMaxDate;
     private boolean mIsClientSpecified24HourTime;
     private boolean mIs24HourTime;
-    private boolean mDefaultDateSelector;
+    private DefaultSelector mDefaultDateSelector;
 
     private Calendar mCalendar;
     private int mDateFlags =
@@ -85,8 +86,8 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
      * @return
      */
     public static SlideDateTimeDialogFragment newInstance(SlideDateTimeListener listener,
-            Date initialDate, Date minDate, Date maxDate, boolean isClientSpecified24HourTime,
-            boolean is24HourTime, boolean defaultDateSelctor, int theme, int indicatorColor)
+                                                          Date initialDate, Date minDate, Date maxDate, boolean isClientSpecified24HourTime,
+                                                          boolean is24HourTime, DefaultSelector defaultDateSelctor, int theme, int indicatorColor)
     {
         mListener = listener;
 
@@ -100,7 +101,7 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
         bundle.putSerializable("maxDate", maxDate);
         bundle.putBoolean("isClientSpecified24HourTime", isClientSpecified24HourTime);
         bundle.putBoolean("is24HourTime", is24HourTime);
-        bundle.putBoolean("defaultDateSelector", defaultDateSelctor);
+        bundle.putSerializable("defaultDateSelector", defaultDateSelctor);
         bundle.putInt("theme", theme);
         bundle.putInt("indicatorColor", indicatorColor);
         dialogFragment.setArguments(bundle);
@@ -131,10 +132,10 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
 
         switch (mTheme)
         {
-        case SlideDateTimePicker.HOLO_DARK:
+        case HOLO_DARK:
             setStyle(DialogFragment.STYLE_NO_TITLE, android.R.style.Theme_Holo_Dialog_NoActionBar);
             break;
-        case SlideDateTimePicker.HOLO_LIGHT:
+        case HOLO_LIGHT:
             setStyle(DialogFragment.STYLE_NO_TITLE, android.R.style.Theme_Holo_Light_Dialog_NoActionBar);
             break;
         default:  // if no theme was specified, default to holo light
@@ -179,7 +180,7 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
         mMaxDate = (Date) args.getSerializable("maxDate");
         mIsClientSpecified24HourTime = args.getBoolean("isClientSpecified24HourTime");
         mIs24HourTime = args.getBoolean("is24HourTime");
-        mDefaultDateSelector = args.getBoolean("defaultDateSelector");
+        mDefaultDateSelector = (DefaultSelector) args.getSerializable("defaultDateSelector");
         mTheme = args.getInt("theme");
         mIndicatorColor = args.getInt("indicatorColor");
     }
@@ -196,7 +197,7 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
 
     private void customizeViews()
     {
-        int lineColor = mTheme == SlideDateTimePicker.HOLO_DARK ?
+        int lineColor = mTheme == HOLO_DARK ?
                 getResources().getColor(R.color.gray_holo_dark) :
                 getResources().getColor(R.color.gray_holo_light);
 
@@ -204,8 +205,8 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
         // bottom buttons depending on the theme.
         switch (mTheme)
         {
-        case SlideDateTimePicker.HOLO_LIGHT:
-        case SlideDateTimePicker.HOLO_DARK:
+        case HOLO_LIGHT:
+        case HOLO_DARK:
             mButtonHorizontalDivider.setBackgroundColor(lineColor);
             mButtonVerticalDivider.setBackgroundColor(lineColor);
             break;
@@ -243,7 +244,7 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
     }
 
     private void updateViewPager() {
-        mViewPager.setCurrentItem((mDefaultDateSelector)?0:1);
+        mViewPager.setCurrentItem(mDefaultDateSelector == DefaultSelector.DATE?0:1);
     }
 
     private void initButtons()

--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimeDialogFragment.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimeDialogFragment.java
@@ -54,6 +54,8 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
     private Date mMaxDate;
     private boolean mIsClientSpecified24HourTime;
     private boolean mIs24HourTime;
+    private boolean mDefaultDateSelector;
+
     private Calendar mCalendar;
     private int mDateFlags =
         DateUtils.FORMAT_SHOW_WEEKDAY |
@@ -77,13 +79,14 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
      * @param maxDate
      * @param isClientSpecified24HourTime
      * @param is24HourTime
+     * @param defaultDateSelctor
      * @param theme
      * @param indicatorColor
      * @return
      */
     public static SlideDateTimeDialogFragment newInstance(SlideDateTimeListener listener,
             Date initialDate, Date minDate, Date maxDate, boolean isClientSpecified24HourTime,
-            boolean is24HourTime, int theme, int indicatorColor)
+            boolean is24HourTime, boolean defaultDateSelctor, int theme, int indicatorColor)
     {
         mListener = listener;
 
@@ -97,6 +100,7 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
         bundle.putSerializable("maxDate", maxDate);
         bundle.putBoolean("isClientSpecified24HourTime", isClientSpecified24HourTime);
         bundle.putBoolean("is24HourTime", is24HourTime);
+        bundle.putBoolean("defaultDateSelector", defaultDateSelctor);
         bundle.putInt("theme", theme);
         bundle.putInt("indicatorColor", indicatorColor);
         dialogFragment.setArguments(bundle);
@@ -175,6 +179,7 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
         mMaxDate = (Date) args.getSerializable("maxDate");
         mIsClientSpecified24HourTime = args.getBoolean("isClientSpecified24HourTime");
         mIs24HourTime = args.getBoolean("is24HourTime");
+        mDefaultDateSelector = args.getBoolean("defaultDateSelector");
         mTheme = args.getInt("theme");
         mIndicatorColor = args.getInt("indicatorColor");
     }
@@ -219,7 +224,6 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
     {
         mViewPagerAdapter = new ViewPagerAdapter(getChildFragmentManager());
         mViewPager.setAdapter(mViewPagerAdapter);
-
         // Setting this custom layout for each tab ensures that the tabs will
         // fill all available horizontal space.
         mSlidingTabLayout.setCustomTabView(R.layout.custom_tab, R.id.tabText);
@@ -233,6 +237,13 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
 
         // Set initial time on time tab
         updateTimeTab();
+
+        //Set initial tab
+        updateViewPager();
+    }
+
+    private void updateViewPager() {
+        mViewPager.setCurrentItem((mDefaultDateSelector)?0:1);
     }
 
     private void initButtons()

--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimePicker.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimePicker.java
@@ -30,6 +30,7 @@ public class SlideDateTimePicker
     private boolean mIs24HourTime;
     private int mTheme;
     private int mIndicatorColor;
+    private boolean mDefaultDateSelector;
 
     /**
      * Creates a new instance of {@code SlideDateTimePicker}.
@@ -155,7 +156,7 @@ public class SlideDateTimePicker
 
     /**
      * Shows the dialog to the user. Make sure to call
-     * {@link #setListener()} before calling this.
+     * {@link #setListener(SlideDateTimeListener)} ()} before calling this.
      */
     public void show()
     {
@@ -178,11 +179,21 @@ public class SlideDateTimePicker
                         mMaxDate,
                         mIsClientSpecified24HourTime,
                         mIs24HourTime,
+                        mDefaultDateSelector,
                         mTheme,
                         mIndicatorColor);
 
         dialogFragment.show(mFragmentManager,
                 SlideDateTimeDialogFragment.TAG_SLIDE_DATE_TIME_DIALOG_FRAGMENT);
+    }
+
+    /**
+     *
+     * @param defaultDateSelector if true or unset default to date tab otherwise show time tab on initial load
+     */
+
+    public void setDefaultDateSelector(boolean defaultDateSelector) {
+        this.mDefaultDateSelector = defaultDateSelector;
     }
 
     /*
@@ -201,6 +212,7 @@ public class SlideDateTimePicker
         private Date maxDate;
         private boolean isClientSpecified24HourTime;
         private boolean is24HourTime;
+        private boolean defaultSelectorToDate = true;
         private int theme;
         private int indicatorColor;
 
@@ -274,15 +286,25 @@ public class SlideDateTimePicker
         }
 
         /**
+         *
+         * @see SlideDateTimePicker#setDefaultDateSelector(boolean)
+         *
+         */
+
+        public Builder setDefaultSelector(boolean isDateSelector){
+            this.defaultSelectorToDate = isDateSelector;
+            return this;
+        }
+
+        /**
          * <p>Build and return a {@code SlideDateTimePicker} object based on the previously
          * supplied parameters.</p>
-         *
+         * <p>
          * <p>You should call {@link #show()} immediately after this.</p>
          *
          * @return
          */
-        public SlideDateTimePicker build()
-        {
+        public SlideDateTimePicker build() {
             SlideDateTimePicker picker = new SlideDateTimePicker(fm);
             picker.setListener(listener);
             picker.setInitialDate(initialDate);
@@ -291,6 +313,7 @@ public class SlideDateTimePicker
             picker.setIsClientSpecified24HourTime(isClientSpecified24HourTime);
             picker.setIs24HourTime(is24HourTime);
             picker.setTheme(theme);
+            picker.setDefaultDateSelector(defaultSelectorToDate);
             picker.setIndicatorColor(indicatorColor);
 
             return picker;

--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimePicker.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimePicker.java
@@ -30,7 +30,7 @@ public class SlideDateTimePicker
     private boolean mIs24HourTime;
     private int mTheme;
     private int mIndicatorColor;
-    private boolean mDefaultDateSelector;
+    private SlideDateTimePicker.DefaultSelector mDefaultDateSelector;
 
     /**
      * Creates a new instance of {@code SlideDateTimePicker}.
@@ -192,8 +192,12 @@ public class SlideDateTimePicker
      * @param defaultDateSelector if true or unset default to date tab otherwise show time tab on initial load
      */
 
-    public void setDefaultDateSelector(boolean defaultDateSelector) {
+    public void setDefaultDateSelector(DefaultSelector defaultDateSelector) {
         this.mDefaultDateSelector = defaultDateSelector;
+    }
+
+    public enum DefaultSelector {
+        DATE, TIME
     }
 
     /*
@@ -212,7 +216,7 @@ public class SlideDateTimePicker
         private Date maxDate;
         private boolean isClientSpecified24HourTime;
         private boolean is24HourTime;
-        private boolean defaultSelectorToDate = true;
+        private DefaultSelector defaultSelectorToDate = DefaultSelector.DATE;
         private int theme;
         private int indicatorColor;
 
@@ -287,12 +291,12 @@ public class SlideDateTimePicker
 
         /**
          *
-         * @see SlideDateTimePicker#setDefaultDateSelector(boolean)
+         * @see SlideDateTimePicker#setDefaultDateSelector(DefaultSelector)
          *
          */
 
-        public Builder setDefaultSelector(boolean isDateSelector){
-            this.defaultSelectorToDate = isDateSelector;
+        public Builder setDefaultSelector(DefaultSelector defaultSelector){
+            this.defaultSelectorToDate = defaultSelector;
             return this;
         }
 
@@ -302,7 +306,7 @@ public class SlideDateTimePicker
          * <p>
          * <p>You should call {@link #show()} immediately after this.</p>
          *
-         * @return
+         * @return SlideDateTimePicker
          */
         public SlideDateTimePicker build() {
             SlideDateTimePicker picker = new SlideDateTimePicker(fm);

--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/TimeFragment.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/TimeFragment.java
@@ -52,7 +52,7 @@ public class TimeFragment extends Fragment
 
         try
         {
-            mCallback = (TimeChangedListener) getTargetFragment();
+            mCallback = (TimeChangedListener) getParentFragment();
         }
         catch (ClassCastException e)
         {
@@ -64,7 +64,7 @@ public class TimeFragment extends Fragment
     /**
      * Return an instance of TimeFragment with its bundle filled with the
      * constructor arguments. The values in the bundle are retrieved in
-     * {@link #onCreateView()} below to properly initialize the TimePicker.
+     * {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)} below to properly initialize the TimePicker.
      *
      * @param theme
      * @param hour

--- a/slideDateTimePickerSample/build.gradle
+++ b/slideDateTimePickerSample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.github.jjobes.slidedatetimepicker.sample"

--- a/slideDateTimePickerSample/build.gradle
+++ b/slideDateTimePickerSample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.github.jjobes.slidedatetimepicker.sample"
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 26
     }
 
     buildTypes {
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile project(':slideDateTimePicker')
-    compile 'com.android.support:support-v4:23.1.1'
+    compile 'com.android.support:support-v4:26.1.0'
 }

--- a/slideDateTimePickerSample/src/main/java/com/github/jjobes/slidedatetimepicker/sample/SampleActivity.java
+++ b/slideDateTimePickerSample/src/main/java/com/github/jjobes/slidedatetimepicker/sample/SampleActivity.java
@@ -66,6 +66,7 @@ public class SampleActivity extends FragmentActivity
                     //.setIs24HourTime(true)
                     //.setTheme(SlideDateTimePicker.HOLO_DARK)
                     //.setIndicatorColor(Color.parseColor("#990000"))
+                    //.setDefaultSelector(false)
                     .build()
                     .show();
             }

--- a/slideDateTimePickerSample/src/main/java/com/github/jjobes/slidedatetimepicker/sample/SampleActivity.java
+++ b/slideDateTimePickerSample/src/main/java/com/github/jjobes/slidedatetimepicker/sample/SampleActivity.java
@@ -66,7 +66,7 @@ public class SampleActivity extends FragmentActivity
                     //.setIs24HourTime(true)
                     //.setTheme(SlideDateTimePicker.HOLO_DARK)
                     //.setIndicatorColor(Color.parseColor("#990000"))
-                    //.setDefaultSelector(false)
+                    //.setDefaultSelector(SlideDateTimePicker.DefaultSelector.TIME)
                     .build()
                     .show();
             }


### PR DESCRIPTION
I have added the ability to allow the user to specify in the build if they want to default to the date picker tab vs the time picker tab.
backwards compatability is kept (if not specified defaults to date tab)
added example to sampleActivity