### PR TITLE
Changed calls to getTargetFragment() to getParentFragment() to solve crashes on rotation

### DIFF
--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/DateFragment.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/DateFragment.java
@@ -50,7 +50,7 @@ public class DateFragment extends Fragment
 
         try
         {
-            mCallback = (DateChangedListener) getTargetFragment();
+            mCallback = (DateChangedListener) getParentFragment();
         }
         catch (ClassCastException e)
         {

--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimeDialogFragment.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/SlideDateTimeDialogFragment.java
@@ -379,7 +379,7 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
                     mCalendar.get(Calendar.DAY_OF_MONTH),
                     mMinDate,
                     mMaxDate);
-                dateFragment.setTargetFragment(SlideDateTimeDialogFragment.this, 100);
+              //  dateFragment.setTargetFragment(SlideDateTimeDialogFragment.this, 100);
                 return dateFragment;
             case 1:
                 TimeFragment timeFragment = TimeFragment.newInstance(
@@ -388,7 +388,7 @@ public class SlideDateTimeDialogFragment extends DialogFragment implements DateF
                     mCalendar.get(Calendar.MINUTE),
                     mIsClientSpecified24HourTime,
                     mIs24HourTime);
-                timeFragment.setTargetFragment(SlideDateTimeDialogFragment.this, 200);
+              //  timeFragment.setTargetFragment(SlideDateTimeDialogFragment.this, 200);
                 return timeFragment;
             default:
                 return null;

--- a/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/TimeFragment.java
+++ b/slideDateTimePicker/src/main/java/com/github/jjobes/slidedatetimepicker/TimeFragment.java
@@ -52,7 +52,7 @@ public class TimeFragment extends Fragment
 
         try
         {
-            mCallback = (TimeChangedListener) getTargetFragment();
+            mCallback = (TimeChangedListener) getParentFragment();
         }
         catch (ClassCastException e)
         {
@@ -141,7 +141,7 @@ public class TimeFragment extends Fragment
             // If the client does not specify a 24-hour time format, use the
             // device default.
             mTimePicker.setIs24HourView(DateFormat.is24HourFormat(
-                getTargetFragment().getActivity()));
+                getParentFragment().getActivity()));
         }
 
         mTimePicker.setCurrentHour(initialHour);


### PR DESCRIPTION
The app would crash on rotation or backgrounding. That is due to the target fragment not being found when the hosting fragment is recreated. According to the discussions here: https://issuetracker.google.com/issues/36969568
and in many other places, the issue mainly is caused by the calls to setTargetFragment() and getTargetFragment(). The SlideDateTimeDialogFragment class calls for the ChildFragmentManager (as opposed to a FragmentManager) when instantiating the ViewPagerAdapter. Therefore, the DateFragment and TimeFragment should have the Dialog as parent. 
The issue is solved by changing the calls to getTargetFragment() in the callbacks from TimeFragment and DateFragment to be calls to getParentFragment(), and by removing the calls to setTargetFragment() in the getItem() method of the SlideDateTimeDialogFragment class.
